### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/run_full_examples.yml
+++ b/.github/workflows/run_full_examples.yml
@@ -10,10 +10,9 @@ on:
   workflow_dispatch:
 
 env:
-  RPC_URL: ${{ secrets.RPC_URL }}
+  ETHEREUM_RPC_URL: ${{ secrets.RPC_URL }}
   LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
   FAILURE_WEBHOOK: ${{secrets.FAILURE_WEBHOOK}}
-  CHAIN: ethereum
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,13 +1,16 @@
 name: Coverage
 
+# To be re-enabled if we use pytest in the example repository.
+# For now all tests are run in the private repository, with extensive coverage.
+
 on:
-  push:
-    branches: [ main, dev ]
-  pull_request:
-    branches: '*'
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 */3 * *'   # Runs at midnight every 3 days
+#  push:
+#    branches: [ main, dev ]
+#  pull_request:
+#    branches: '*'
+#  workflow_dispatch:
+#  schedule:
+#    - cron: '0 0 */3 * *'   # Runs at midnight every 3 days
 
 env:
   RPC_URL: ${{ secrets.RPC_URL }}


### PR DESCRIPTION
Some of our workflows are out of date. 

These workflows have limited use, since we rely heavily on test coverage within our private repository. 

We should make the workflows in this repository work, or remove them if they are not useful. 